### PR TITLE
Update hwdec_cuda to work with libplacebo ra_pl contexts

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -50,7 +50,7 @@ extern const struct ra_ctx_fns ra_ctx_vdpauglx;
 
 /* Vulkan */
 extern const struct ra_ctx_fns ra_ctx_vulkan_wayland;
-//extern const struct ra_ctx_fns ra_ctx_vulkan_win;
+extern const struct ra_ctx_fns ra_ctx_vulkan_win;
 extern const struct ra_ctx_fns ra_ctx_vulkan_xlib;
 
 /* Direct3D 11 */
@@ -105,11 +105,9 @@ static const struct ra_ctx_fns *contexts[] = {
 // Vulkan contexts:
 #if HAVE_VULKAN
 
-/*
 #if HAVE_WIN32_DESKTOP
     &ra_ctx_vulkan_win,
 #endif
-*/
 #if HAVE_WAYLAND
     &ra_ctx_vulkan_wayland,
 #endif

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -8,13 +8,18 @@ struct ra_pl {
     const struct pl_gpu *gpu;
 };
 
-static inline const struct pl_gpu *get_gpu(struct ra *ra)
+static inline const struct pl_gpu *get_gpu(const struct ra *ra)
 {
     struct ra_pl *p = ra->priv;
     return p->gpu;
 }
 
 static struct ra_fns ra_fns_pl;
+
+const struct pl_gpu *ra_pl_get(const struct ra *ra)
+{
+    return ra->fns == &ra_fns_pl ? get_gpu(ra) : NULL;
+}
 
 struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log)
 {

--- a/video/out/placebo/ra_pl.h
+++ b/video/out/placebo/ra_pl.h
@@ -5,6 +5,8 @@
 
 struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log);
 
+const struct pl_gpu *ra_pl_get(const struct ra *ra);
+
 // Wrap a pl_tex into a ra_tex struct, returns if successful
 bool mppl_wrap_tex(struct ra *ra, const struct pl_tex *pltex,
                    struct ra_tex *out_tex);

--- a/video/out/placebo/ra_pl.h
+++ b/video/out/placebo/ra_pl.h
@@ -7,6 +7,11 @@ struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log);
 
 const struct pl_gpu *ra_pl_get(const struct ra *ra);
 
+static inline const struct pl_fmt *ra_pl_fmt_get(const struct ra_format *format)
+{
+    return format->priv;
+}
+
 // Wrap a pl_tex into a ra_tex struct, returns if successful
 bool mppl_wrap_tex(struct ra *ra, const struct pl_tex *pltex,
                    struct ra_tex *out_tex);

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -1,0 +1,104 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "video/out/gpu/context.h"
+#include "video/out/w32_common.h"
+
+#include "common.h"
+#include "context.h"
+#include "utils.h"
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
+
+struct priv {
+    struct mpvk_ctx vk;
+};
+
+static void win_uninit(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+
+    ra_vk_ctx_uninit(ctx);
+    mpvk_uninit(&p->vk);
+    vo_w32_uninit(ctx->vo);
+}
+
+static bool win_init(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
+    struct mpvk_ctx *vk = &p->vk;
+    int msgl = ctx->opts.probing ? MSGL_V : MSGL_ERR;
+
+    if (!mpvk_init(vk, ctx, VK_KHR_WIN32_SURFACE_EXTENSION_NAME))
+        goto error;
+
+    if (!vo_w32_init(ctx->vo))
+        goto error;
+
+    VkWin32SurfaceCreateInfoKHR wininfo = {
+         .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+         .hinstance = HINST_THISCOMPONENT,
+         .hwnd = vo_w32_hwnd(ctx->vo),
+    };
+
+    VkInstance inst = vk->vkinst->instance;
+    VkResult res = vkCreateWin32SurfaceKHR(inst, &wininfo, NULL, &vk->surface);
+    if (res != VK_SUCCESS) {
+        MP_MSG(ctx, msgl, "Failed creating Windows surface\n");
+        goto error;
+    }
+
+    if (!ra_vk_ctx_init(ctx, vk, VK_PRESENT_MODE_FIFO_KHR))
+        goto error;
+
+    return true;
+
+error:
+    win_uninit(ctx);
+    return false;
+}
+
+static bool resize(struct ra_ctx *ctx)
+{
+    return ra_vk_ctx_resize(ctx, ctx->vo->dwidth, ctx->vo->dheight);
+}
+
+static bool win_reconfig(struct ra_ctx *ctx)
+{
+    vo_w32_config(ctx->vo);
+    return resize(ctx);
+}
+
+static int win_control(struct ra_ctx *ctx, int *events, int request, void *arg)
+{
+    int ret = vo_w32_control(ctx->vo, events, request, arg);
+    if (*events & VO_EVENT_RESIZE) {
+        if (!resize(ctx))
+            return VO_ERROR;
+    }
+    return ret;
+}
+
+const struct ra_ctx_fns ra_ctx_vulkan_win = {
+    .type           = "vulkan",
+    .name           = "winvk",
+    .reconfig       = win_reconfig,
+    .control        = win_control,
+    .init           = win_init,
+    .uninit         = win_uninit,
+};

--- a/wscript
+++ b/wscript
@@ -852,7 +852,7 @@ hwaccel_features = [
     }, {
         'name': 'ffnvcodec',
         'desc': 'CUDA Headers and dynamic loader',
-        'func': check_pkg_config('ffnvcodec >= 8.2.15.3'),
+        'func': check_pkg_config('ffnvcodec >= 8.2.15.7'),
     }, {
         'name': '--cuda-hwaccel',
         'desc': 'CUDA hwaccel',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -495,7 +495,7 @@ def build(ctx):
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
-        #( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
+        ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),
         ( "video/out/vulkan/utils.c",            "vulkan" ),
         ( "video/out/w32_common.c",              "win32-desktop" ),


### PR DESCRIPTION
This patch series updates hwdec_cuda to work with the libplacebo branch. It also includes the switch over to use image (rather than buffer) based interop, which has finally been fixed in the nvidia driver.